### PR TITLE
fix: populate existing UAC columns

### DIFF
--- a/src/mocks/csv-mocks.ts
+++ b/src/mocks/csv-mocks.ts
@@ -20,6 +20,18 @@ export const validSampleCsvWithExistingUacColumns = `serial_number,Name,UAC1,UAC
 100000003,Bart Simpson,,,,2675465026,bart@spring.field
 `;
 
+export const validSampleCsvWithExistingLowercaseUacColumns = `serial_number,Name,uac1,uac2,uac3,Phone Number,Email
+100000001,Homer Simpson,,,,5551234422,homer@springfield.com
+100000002,Seymour Skinner,,,,1235663322,a@b.c
+100000003,Bart Simpson,,,,2675465026,bart@spring.field
+`;
+
+export const validSampleCsvWithExistingMixedCaseUacColumns = `serial_number,Name,UaC1,UaC2,UaC3,Phone Number,Email
+100000001,Homer Simpson,,,,5551234422,homer@springfield.com
+100000002,Seymour Skinner,,,,1235663322,a@b.c
+100000003,Bart Simpson,,,,2675465026,bart@spring.field
+`;
+
 export const validSampleCsvWithExistingUacEntries = `serial_number,Name,UAC1,UAC2,UAC3,Phone Number,Email
 100000001,Homer Simpson,3454,5453,5353,5551234422,homer@springfield.com
 100000002,Seymour Skinner,8786,2213,3343,1235663322,a@b.c

--- a/src/server/utils/csv-parser.test.ts
+++ b/src/server/utils/csv-parser.test.ts
@@ -8,7 +8,7 @@ import {
     unMatchedInstrumentUacDetails,
     emptyInstrumentUacDetails,
     partialMatchedInstrumentUacDetails,
-    validSampleCsvWithExistingUacEntries, validSampleCsvWithExistingUacColumns
+    validSampleCsvWithExistingUacEntries, validSampleCsvWithExistingLowercaseUacColumns, validSampleCsvWithExistingMixedCaseUacColumns, validSampleCsvWithExistingUacColumns
 } from "../../mocks/csv-mocks";
 
 describe("getUacsFromFile tests", () => {
@@ -259,5 +259,85 @@ describe("addUacCodesToFile tests", () => {
         expect(result).toEqual([]);
 
         expect(console.error).toHaveBeenCalledWith("Unexpected Error: column header mismatch expected: 3 columns got: 4");
+    });
+
+    it("Uploaded CSV with lowercase UAC headings - returns CSV with those columns populated", async () =>{
+        console.error = jest.fn();
+        const fileData = Buffer.from(validSampleCsvWithExistingLowercaseUacColumns);
+
+        const result = await addUacCodesToFile(fileData, matchedInstrumentUacDetails);
+        
+        expect(result).toHaveLength(3);
+        expect(result).toContainEqual({
+            "serial_number": "100000001",
+            "Name": "Homer Simpson",
+            "uac1": "0009",
+            "uac2": "7565",
+            "uac3": "3827",
+            "UAC": "000975653827",
+            "Phone Number": "5551234422",
+            "Email": "homer@springfield.com"
+        });
+        expect(result).toContainEqual({
+            "serial_number": "100000002",
+            "Name": "Seymour Skinner",
+            "uac1": "3453",
+            "uac2": "6545",
+            "uac3": "4564",
+            "UAC": "345365454564",
+            "Phone Number": "1235663322",
+            "Email": "a@b.c"
+        });
+        expect(result).toContainEqual({
+            "serial_number": "100000003",
+            "Name": "Bart Simpson",
+            "uac1": "9789",
+            "uac2": "7578",
+            "uac3": "5367",
+            "UAC": "978975785367",
+            "Phone Number": "2675465026",
+            "Email": "bart@spring.field"
+        });
+
+    });
+
+    it("Uploaded CSV with mixed case UAC headings - returns CSV with those columns populated", async () =>{
+        console.error = jest.fn();
+        const fileData = Buffer.from(validSampleCsvWithExistingMixedCaseUacColumns);
+
+        const result = await addUacCodesToFile(fileData, matchedInstrumentUacDetails);
+        
+        expect(result).toHaveLength(3);
+        expect(result).toContainEqual({
+            "serial_number": "100000001",
+            "Name": "Homer Simpson",
+            "UaC1": "0009",
+            "UaC2": "7565",
+            "UaC3": "3827",
+            "UAC": "000975653827",
+            "Phone Number": "5551234422",
+            "Email": "homer@springfield.com"
+        });
+        expect(result).toContainEqual({
+            "serial_number": "100000002",
+            "Name": "Seymour Skinner",
+            "UaC1": "3453",
+            "UaC2": "6545",
+            "UaC3": "4564",
+            "UAC": "345365454564",
+            "Phone Number": "1235663322",
+            "Email": "a@b.c"
+        });
+        expect(result).toContainEqual({
+            "serial_number": "100000003",
+            "Name": "Bart Simpson",
+            "UaC1": "9789",
+            "UaC2": "7578",
+            "UaC3": "5367",
+            "UAC": "978975785367",
+            "Phone Number": "2675465026",
+            "Email": "bart@spring.field"
+        });
+
     });
 });

--- a/src/server/utils/csv-parser.ts
+++ b/src/server/utils/csv-parser.ts
@@ -51,6 +51,12 @@ export function getCaseIdsFromFile(fileData: string | Buffer): Promise<string[]>
 
 export function addUacCodesToFile(fileData: string | Buffer, instrumentUacDetails: InstrumentUacDetailsByCaseId): Promise<Record<string, string>[]> {
     const readStream = Readable.from(fileData);
+    var uacHeading1 = "UAC1";
+    var uacHeading2 = "UAC2";
+    var uacHeading3 = "UAC3";
+    var uacHeading4 = "UAC4";
+    var uacHeadingFull = "UAC";
+    var uacHeadings = [uacHeading1, uacHeading2, uacHeading3, uacHeading4, uacHeadingFull];
 
     return new Promise((resolve, reject) => {
         const results: Record<string, string>[] = [];
@@ -61,6 +67,18 @@ export function addUacCodesToFile(fileData: string | Buffer, instrumentUacDetail
                 }
                 return true;
             })
+            .on("headers", (headers: string[]) => { 
+                headers.forEach(function (string){
+                    uacHeadings.forEach(function (heading){
+                        if ((string.localeCompare(heading, 'en', { sensitivity: 'accent' }) == 0)){
+                            var index = uacHeadings.indexOf(heading);
+                            if (~index){
+                                uacHeadings[index] = string;
+                            }
+                        }    
+                    });
+                })
+            })
             .on("data-invalid", (row) => {
                 console.error(`No UAC chunks found that matches the case id ${row.serial_number}`);
                 resolve([]);
@@ -70,7 +88,7 @@ export function addUacCodesToFile(fileData: string | Buffer, instrumentUacDetail
                 resolve([]);
             })
             .on("data", (row) => {
-                results.push(mapUacChunk(row, instrumentUacDetails));
+                results.push(mapUacChunk(uacHeadings, row, instrumentUacDetails));
             })
             .on("end", () => {
                 resolve(results);
@@ -78,19 +96,19 @@ export function addUacCodesToFile(fileData: string | Buffer, instrumentUacDetail
     });
 }
 
-function mapUacChunk(line: Record<string, string>, instrumentUacDetails: InstrumentUacDetailsByCaseId): Record<string, string> {
+function mapUacChunk(uacHeadings: string[], line: Record<string, string>, instrumentUacDetails: InstrumentUacDetailsByCaseId): Record<string, string> {
     const uacDetails = instrumentUacDetails[line.serial_number];
-
-    line["UAC1"] ? line["UAC1"] = uacDetails.uac_chunks.uac1 : line.UAC1 = uacDetails.uac_chunks.uac1;
-    line["UAC2"] ? line["UAC2"] = uacDetails.uac_chunks.uac2 : line.UAC2 = uacDetails.uac_chunks.uac2;
-    line["UAC3"] ? line["UAC3"] = uacDetails.uac_chunks.uac3 : line.UAC3 = uacDetails.uac_chunks.uac3;
+       
+    line[uacHeadings[0]] ? line[uacHeadings[0]] = uacDetails.uac_chunks.uac1 : line[uacHeadings[0]] = uacDetails.uac_chunks.uac1;
+    line[uacHeadings[1]] ? line[uacHeadings[1]] = uacDetails.uac_chunks.uac2 : line[uacHeadings[1]] = uacDetails.uac_chunks.uac2;
+    line[uacHeadings[2]] ? line[uacHeadings[2]] = uacDetails.uac_chunks.uac3 : line[uacHeadings[2]] = uacDetails.uac_chunks.uac3;
 
     if (uacDetails.uac_chunks.uac4) {
-        line["UAC4"] ? line["UAC4"] = uacDetails.uac_chunks.uac4 : line.UAC4 = uacDetails.uac_chunks.uac4;
+        line[uacHeadings[3]] ? line[uacHeadings[3]] = uacDetails.uac_chunks.uac4 : line[uacHeadings[3]] = uacDetails.uac_chunks.uac4;
     }
 
     if (uacDetails.full_uac) {
-        line["UAC"] ? line["UAC"] = uacDetails.full_uac : line.UAC = uacDetails.full_uac;
+        line[uacHeadings[4]] ? line[uacHeadings[4]] = uacDetails.full_uac : line[uacHeadings[4]] = uacDetails.full_uac;
     }
 
     return line;

--- a/src/server/utils/csv-parser.ts
+++ b/src/server/utils/csv-parser.ts
@@ -99,16 +99,16 @@ export function addUacCodesToFile(fileData: string | Buffer, instrumentUacDetail
 function mapUacChunk(uacHeadings: string[], line: Record<string, string>, instrumentUacDetails: InstrumentUacDetailsByCaseId): Record<string, string> {
     const uacDetails = instrumentUacDetails[line.serial_number];
        
-    line[uacHeadings[0]] ? line[uacHeadings[0]] = uacDetails.uac_chunks.uac1 : line[uacHeadings[0]] = uacDetails.uac_chunks.uac1;
-    line[uacHeadings[1]] ? line[uacHeadings[1]] = uacDetails.uac_chunks.uac2 : line[uacHeadings[1]] = uacDetails.uac_chunks.uac2;
-    line[uacHeadings[2]] ? line[uacHeadings[2]] = uacDetails.uac_chunks.uac3 : line[uacHeadings[2]] = uacDetails.uac_chunks.uac3;
+    line[uacHeadings[0]] = uacDetails.uac_chunks.uac1;
+    line[uacHeadings[1]] = uacDetails.uac_chunks.uac2;
+    line[uacHeadings[2]] = uacDetails.uac_chunks.uac3;
 
     if (uacDetails.uac_chunks.uac4) {
-        line[uacHeadings[3]] ? line[uacHeadings[3]] = uacDetails.uac_chunks.uac4 : line[uacHeadings[3]] = uacDetails.uac_chunks.uac4;
+        line[uacHeadings[3]] = uacDetails.uac_chunks.uac4;
     }
 
     if (uacDetails.full_uac) {
-        line[uacHeadings[4]] ? line[uacHeadings[4]] = uacDetails.full_uac : line[uacHeadings[4]] = uacDetails.full_uac;
+        line[uacHeadings[4]] = uacDetails.full_uac;
     }
 
     return line;


### PR DESCRIPTION
Where there are existing UAC columns, populate existing instead of creating new regardless of case.

Refs: BLAIS5-2972